### PR TITLE
Adds a default PassThroughRule for tag `<sup>`

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -27,6 +27,9 @@
         "class": "ParagraphRule",
         "selector": "p"
     }, {
+        "class": "PassThroughRule",
+        "selector": "sup"
+    }, {
         "class": "LineBreakRule",
         "selector": "br"
     }, {


### PR DESCRIPTION
This PR:

* [x] Adds PassThroughRule for tag `<sup>`

Fixes #615 
