### PR TITLE
Adds parameter to format article before ingestion

### DIFF
--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -125,13 +125,16 @@ class Instant_Articles_Publisher {
 					$published = apply_filters( 'instant_articles_post_published', true, $post_id );
 				}
 
+				// Checks if it will render article formatted - With spaces and tabs.
+				$publishArticleFormatted = isset( $publishing_settings[ 'publish_formatted' ] ) ? (bool) $publishing_settings[ 'publish_formatted' ] : false;
+
 				try {
 					// Import the article.
-					$submission_id = $client->importArticle( $article, $published );
+					$submission_id = $client->importArticle( $article, $published, true, $publishArticleFormatted );
 					update_post_meta( $post_id, self::SUBMISSION_ID_KEY, $submission_id );
 				} catch ( Exception $e ) {
 					// Try without taking live for pages not yet reviewed.
-					$submission_id = $client->importArticle( $article, false );
+					$submission_id = $client->importArticle( $article, false, true, $publishArticleFormatted );
 					update_post_meta( $post_id, self::SUBMISSION_ID_KEY, $submission_id );
 				}
 			}

--- a/meta-box/meta-box-template.php
+++ b/meta-box/meta-box-template.php
@@ -200,7 +200,7 @@ use Facebook\InstantArticles\Client\ServerMessage;
 	</div>
 	<div>
 		<label for="transformed">Transformed Markup:</label>
-		<textarea class="source" readonly><?php echo esc_textarea( $article->render( '', true ) ); ?></textarea>
+		<textarea class="source" readonly><?php echo esc_textarea( $article->render( null, true ) ); ?></textarea>
 	</div>
 	<br clear="all">
 </div>

--- a/wizard/class-instant-articles-option-publishing.php
+++ b/wizard/class-instant-articles-option-publishing.php
@@ -55,6 +55,14 @@ class Instant_Articles_Option_Publishing extends Instant_Articles_Option {
 			'checkbox_label' => 'Publish articles containing warnings',
 		),
 
+		'publish_formatted' => array(
+			'label' => 'Format articles',
+			'description' => 'With this option enabled, articles will be formatted before ingestion. This helps finding errors and understand the final markup Instant Article document.',
+			'render' => 'checkbox',
+			'default' => false,
+			'checkbox_label' => 'Publish articles formatted',
+		),
+
 		'likes_on_media' => array(
 			'label' => 'Likes',
 			'description' => 'With this option enabled, any image or video will have the like action enabled by default.',


### PR DESCRIPTION
[x] Depends on PR: https://github.com/facebook/facebook-instant-articles-sdk-php/pull/199
[x] Creates a new checkbox configuration to allow user to activate/deactivate formatting
[x] Uses the configuration to apply the formatting style chosen on setup

Depends on https://github.com/facebook/facebook-instant-articles-sdk-php/pull/199

Fixes #625

