### PR TITLE
Move admin scripts and styles so that they only show on fb instant articles page

### DIFF
--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -320,26 +320,6 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	add_action( 'init', 'instant_articles_register_scripts' );
 
 	/**
-	 * Enqueue all scripts and styles for the admin UI.
-	 *
-	 * @since 0.4
-	 */
-//	function instant_articles_enqueue_scripts() {
-//		wp_enqueue_style( 'instant-articles-meta-box' );
-//		wp_enqueue_style( 'instant-articles-settings-wizard' );
-//		wp_enqueue_style( 'instant-articles-settings' );
-//		wp_enqueue_style( 'instant-articles-wizard' );
-//
-//		wp_enqueue_script( 'instant-articles-meta-box' );
-//		wp_enqueue_script( 'instant-articles-option-ads' );
-//		wp_enqueue_script( 'instant-articles-option-analytics' );
-//		wp_enqueue_script( 'instant-articles-option-publishing' );
-//		wp_enqueue_script( 'instant-articles-settings' );
-//		wp_enqueue_script( 'instant-articles-wizard' );
-//	}
-//	add_action( 'admin_enqueue_scripts', 'instant_articles_enqueue_scripts' );
-
-	/**
 	 * Automatically add meta tag for Instant Articles URL claiming
 	 * when page is set.
 	 *

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -324,20 +324,20 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	 *
 	 * @since 0.4
 	 */
-	function instant_articles_enqueue_scripts() {
-		wp_enqueue_style( 'instant-articles-meta-box' );
-		wp_enqueue_style( 'instant-articles-settings-wizard' );
-		wp_enqueue_style( 'instant-articles-settings' );
-		wp_enqueue_style( 'instant-articles-wizard' );
-
-		wp_enqueue_script( 'instant-articles-meta-box' );
-		wp_enqueue_script( 'instant-articles-option-ads' );
-		wp_enqueue_script( 'instant-articles-option-analytics' );
-		wp_enqueue_script( 'instant-articles-option-publishing' );
-		wp_enqueue_script( 'instant-articles-settings' );
-		wp_enqueue_script( 'instant-articles-wizard' );
-	}
-	add_action( 'admin_enqueue_scripts', 'instant_articles_enqueue_scripts' );
+//	function instant_articles_enqueue_scripts() {
+//		wp_enqueue_style( 'instant-articles-meta-box' );
+//		wp_enqueue_style( 'instant-articles-settings-wizard' );
+//		wp_enqueue_style( 'instant-articles-settings' );
+//		wp_enqueue_style( 'instant-articles-wizard' );
+//
+//		wp_enqueue_script( 'instant-articles-meta-box' );
+//		wp_enqueue_script( 'instant-articles-option-ads' );
+//		wp_enqueue_script( 'instant-articles-option-analytics' );
+//		wp_enqueue_script( 'instant-articles-option-publishing' );
+//		wp_enqueue_script( 'instant-articles-settings' );
+//		wp_enqueue_script( 'instant-articles-wizard' );
+//	}
+//	add_action( 'admin_enqueue_scripts', 'instant_articles_enqueue_scripts' );
 
 	/**
 	 * Automatically add meta tag for Instant Articles URL claiming

--- a/wizard/class-instant-articles-wizard.php
+++ b/wizard/class-instant-articles-wizard.php
@@ -27,7 +27,7 @@ class Instant_Articles_Wizard {
 
 		add_action( 'admin_menu', array( 'Instant_Articles_Wizard', 'menu_items' ) );
 
-		add_filter( 'plugin_action_links_' . IA_PLUGIN_PATH, array( 'Instant_Articles_Wizard', 'add_settings_link_to_plugin_actions' ) );
+        add_filter( 'plugin_action_links_' . IA_PLUGIN_PATH, array( 'Instant_Articles_Wizard', 'add_settings_link_to_plugin_actions' ) );
 
 		add_action( 'admin_init', function () {
 			new Instant_Articles_Option_FB_Page();
@@ -40,6 +40,25 @@ class Instant_Articles_Wizard {
 
 	}
 
+    public static function load_admin_scripts_and_styles(){
+        add_action( 'admin_enqueue_scripts', array( 'Instant_Articles_Wizard', 'instant_articles_enqueue_scripts' ) );
+    }
+
+    public static function instant_articles_enqueue_scripts() {
+        error_log('should be loading scripts and styles now');
+		wp_enqueue_style( 'instant-articles-meta-box' );
+		wp_enqueue_style( 'instant-articles-settings-wizard' );
+		wp_enqueue_style( 'instant-articles-settings' );
+		wp_enqueue_style( 'instant-articles-wizard' );
+
+		wp_enqueue_script( 'instant-articles-meta-box' );
+		wp_enqueue_script( 'instant-articles-option-ads' );
+		wp_enqueue_script( 'instant-articles-option-analytics' );
+		wp_enqueue_script( 'instant-articles-option-publishing' );
+		wp_enqueue_script( 'instant-articles-settings' );
+		wp_enqueue_script( 'instant-articles-wizard' );
+	}
+
 	public static function add_settings_link_to_plugin_actions( $links ) {
 		$link_text = __( 'Settings' );
 		$settings_href = self::get_url();
@@ -49,7 +68,7 @@ class Instant_Articles_Wizard {
 	}
 
 	public static function menu_items() {
-		add_menu_page(
+		$adminpage = add_menu_page(
 			'Instant Articles Setup Wizard',
 			'Instant Articles',
 			'manage_options',
@@ -57,7 +76,8 @@ class Instant_Articles_Wizard {
 			array( 'Instant_Articles_Wizard', 'render' )
 			,'dashicons-facebook'
 		);
-		// Hack to let the URL visible to ajax handlers
+        add_action( 'load-' . $adminpage, array( 'Instant_Articles_Wizard', 'load_admin_scripts_and_styles' ) );
+        // Hack to let the URL visible to ajax handlers
 		update_option( 'instant-articles-wizard-url', menu_page_url( 'instant-articles-wizard', false) );
 	}
 

--- a/wizard/class-instant-articles-wizard.php
+++ b/wizard/class-instant-articles-wizard.php
@@ -40,12 +40,11 @@ class Instant_Articles_Wizard {
 
 	}
 
-    public static function load_admin_scripts_and_styles(){
+    public static function load_admin_scripts_and_styles() {
         add_action( 'admin_enqueue_scripts', array( 'Instant_Articles_Wizard', 'instant_articles_enqueue_scripts' ) );
     }
 
     public static function instant_articles_enqueue_scripts() {
-        error_log('should be loading scripts and styles now');
 		wp_enqueue_style( 'instant-articles-meta-box' );
 		wp_enqueue_style( 'instant-articles-settings-wizard' );
 		wp_enqueue_style( 'instant-articles-settings' );


### PR DESCRIPTION
This PR:

Moves the enqueue of the admin scripts and styles so that they only load on the admin page of instant articles.  

While the scripts & styles are very small, they are still connection requests that are not needed for every other admin page. By not loading them it will make the mobile loading time quicker, and also loading in any country where there is poor networking.

Follows #

Relates to #

Fixes #
