### PR TITLE
Fix inject_ia_markup_meta_tag() to use is_singular() and get_queried_object_id()

### DIFF
--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -373,12 +373,10 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	 * @since 4.0
 	 */
 	function inject_ia_markup_meta_tag() {
-		$post = get_post();
-
-		// If there's no current post, return
-		if ( ! $post ) {
+		if ( !is_singular() )
 			return;
-		}
+		
+		$post = get_post( get_the_ID() );
 
 		// Transform the post to an Instant Article.
 		$adapter = new Instant_Articles_Post( $post );

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -376,7 +376,7 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 		if ( !is_singular() )
 			return;
 		
-		$post = get_post( get_the_ID() );
+		$post = get_post( get_queried_object_id() );
 		
 		if ( ! $post ) {
 			return;

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -377,6 +377,10 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 			return;
 		
 		$post = get_post( get_the_ID() );
+		
+		if ( ! $post ) {
+			return;
+		}
 
 		// Transform the post to an Instant Article.
 		$adapter = new Instant_Articles_Post( $post );


### PR DESCRIPTION
re: #953

Small fix to ensure that before inserting the `ia:markup_url` meta tag, we check that we're on a single-post screen (`is_singular()` which is true for posts, pages and CPT `single.php` views).  
Also uses with `get_post(get_queried_object_id())` rather than relying on globals (no argument or using `get_the_ID()`) so that we always have the right post.

This PR:

* [x] 
* [ ] 
* [ ] 

Follows #

Relates to #

Fixes #
