### PR TITLE
Fix issue with Instagram embed image not displaying.

### DIFF
--- a/embeds.php
+++ b/embeds.php
@@ -121,3 +121,24 @@ function instant_articles_embed_get_html( $provider_name, $html, $url, $attr, $p
 
 	return $html;
 }
+
+/**
+ * Jetpack Compatibility. Re-insert scripts that got "stripped on purpose" in Jetpack.
+ *
+ * @param $content
+ * @param $post_id
+ */
+function instant_articles_jetpack_compatibility($content, $post_id) {
+    // Check if Jetpack stripped and enqueued Instagram embed script.
+    if (wp_script_is('jetpack-instagram-embed', 'enqueued')) {
+        $instagram_embed = '<script async defer src="https://www.instagram.com/embed.js"></script>';
+        $regex = '#<blockquote[^>]+?class="instagram-media"[^>](?:.+?)>(?:.+?)<\/blockquote>#ixs';
+        if (!preg_match_all($regex, $content, $matches, PREG_SET_ORDER)) {
+            return $content;
+        }
+
+        $content = preg_replace($regex, '$0' . $instagram_embed, $content, 1);
+    }
+    return $content;
+}
+add_filter( 'instant_articles_content', 'instant_articles_jetpack_compatibility', 10, 4 );


### PR DESCRIPTION
This PR:

* [x] Fixes issue where IG embed script was stripped in Jetpack. See https://github.com/Automattic/jetpack/blob/1a5111bde9417429b6e7827d5886e79fd277ce4f/modules/shortcodes/instagram.php#L156

Fixes #669 #234.
