### PR TITLE
empty check for facebook page id

### DIFF
--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -72,7 +72,7 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	add_action( 'network_admin_notices', 'instant_articles_setup_admin_notice' ); // also show message on multisite
 	function instant_articles_setup_admin_notice() {
 		global $pagenow;
-		if ( $pagenow === 'plugins.php' && ! Instant_Articles_Option_FB_Page::get_option_decoded()[ "page_id" ] ) {
+		if ( $pagenow === 'plugins.php' && ! empty(Instant_Articles_Option_FB_Page::get_option_decoded()[ "page_id" ]) ) {
 			$settings_url = Instant_Articles_Wizard::get_url();
 			echo '<div class="updated settings-error notice is-dismissible">';
 			echo '<p>Congrats, you\'ve installed the Instant Articles for WP plugin. Now <a href="' . esc_url_raw($settings_url) . '">set it up</a> to start publishing Instant Articles.';


### PR DESCRIPTION
page id empty check for below error

 Notice: Trying to access array offset on value of type null in /home/john/codes/news/wp-content/plugins/fb-instant-articles/facebook-instant-articles.php on line 75

This PR:

* [x] 
* [ ] 
* [ ] 

Follows #

Relates to #

Fixes #
