### PR TITLE
Reduce plugin's cache burden, remote requests

### DIFF
--- a/embeds.php
+++ b/embeds.php
@@ -24,6 +24,12 @@ remove_all_filters( 'embed_oembed_html' );
  */
 function instant_articles_embed_oembed_html( $html, $url, $attr, $post_id ) {
 
+	// Don't try to fix embeds unless we're in Instant Articles context.
+	// No need to populate cache outside of Instant Articles context.
+	if ( ! is_transforming_instant_article() ) {
+		return $html;
+	}
+
 	$cache_key = md5( $url . ':instant_articles_oembed_provider' );
 	$provider_name = get_transient( $cache_key );
 


### PR DESCRIPTION
Cached or not, the result of the remote request is only used to determine if
`instant_articles_embed_get_html()` should be called, which itself returns
early when called outside of the transformation process. If a post is never
published to Instant Articles, neither the remote request nor its cached result
are necessary; due to the filter this is hooked to, it will be called regardless.

On a high-traffic site, or a site without a persistent object cache and limited
MySQL resources, rendering a post that contains many embeds can exhaust
resources or eject from cache data that is of greater benefit to remain in cache.

Follows #775

Relates to #252, #1067, #901