### PR TITLE
Improve tests

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -60,6 +60,11 @@ class Instant_Articles_Post {
 	public $transformer = null;
 
 	/**
+	 * @var InstantArticle|mixed|null
+	 */
+	private $instant_article;
+
+	/**
 	 * Setup data and build the content
 	 *
 	 * @since 0.1

--- a/tests/Facebook/InstantArticles/Transformer/WPTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/WPTransformerTest.php
@@ -6,9 +6,11 @@
  * This source code is licensed under the license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+declare(strict_types=1);
+
 namespace Facebook\InstantArticles\Transformer;
 
-use Facebook\InstantArticles\Transformer\Transformer;
 use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\Elements\Time;
@@ -16,8 +18,7 @@ use Facebook\InstantArticles\Elements\Author;
 
 class WPTransformerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testTransformContent()
-    {
+    public function test_transform_content(): void {
         $json_file = file_get_contents(__DIR__ . '/wp-rules.json');
 
         $instant_article = InstantArticle::create();
@@ -51,13 +52,12 @@ class WPTransformerTest extends \PHPUnit_Framework_TestCase
         $result = $instant_article->render('', true)."\n";
         $expected = file_get_contents(__DIR__ . '/wp-ia.xml');
 
-        $this->assertEquals($expected, $result);
+        self::assertSame($expected, $result);
         // there must be 3 warnings related to <img> inside <li> that is not supported by IA
-        $this->assertEquals(3, count($transformer->getWarnings()));
+        self::assertCount(3, $transformer->getWarnings());
     }
 
-    public function testTitleTransformedWithBold()
-    {
+    public function test_title_transformed_with_bold(): void {
         $transformer = new Transformer();
         $json_file = file_get_contents(__DIR__ . '/wp-rules.json');
         $transformer->loadRules($json_file);
@@ -72,6 +72,6 @@ class WPTransformerTest extends \PHPUnit_Framework_TestCase
         $header = Header::create();
         $transformer->transform($header, $document);
 
-        $this->assertEquals('<h1>Title <b>in bold</b></h1>', $header->getTitle()->render());
+        self::assertSame('<h1>Title <b>in bold</b></h1>', $header->getTitle()->render());
     }
 }

--- a/tests/InstantArticlesPostTest.php
+++ b/tests/InstantArticlesPostTest.php
@@ -7,6 +7,8 @@
  * @package default
  */
 
+declare(strict_types=1);
+
 require_once( './class-instant-articles-post.php' );
 
 /**
@@ -17,40 +19,41 @@ require_once( './class-instant-articles-post.php' );
 class InstantArticlesPostTest extends WP_UnitTestCase {
 
 	protected $post_id;
+	private $instant_articles_post;
 
-	public function set_up() {
-		$user_id = $this->factory->user->create();
-		$post = $this->factory->post->create_and_get( array(
-			'post_author' => $user_id,
-			'post_title' => 'Article title',
-			'post_content' => 'something',
-			'post_excerpt' => 'This is the excerpt.',
-			'post_date' => '',
-			'post_modified' => '',
+	public function set_up(): void {
+		$user_id = self::factory()->user->create();
+		$post    = self::factory()->post->create_and_get(
+			array(
+				'post_author'  => $user_id,
+				'post_title'   => 'Article title',
+				'post_content' => 'something',
+				'post_excerpt' => 'This is the excerpt.',
+				'post_date'    => '',
+				'post_modified' => '',
 			)
 		);
-		$this->post_id = $post->ID;
+		$this->post_id               = $post->ID;
 		$this->instant_articles_post = new Instant_Articles_Post( $post );
 	}
 
-	public function testCreateInstance() {
-		$this->assertInstanceOf( 'Instant_Articles_Post', $this->instant_articles_post );
+	public function test_can_create_instance(): void {
+		self::assertInstanceOf( 'Instant_Articles_Post', $this->instant_articles_post );
 	}
 
-	public function testGetPostFields() {
-
-		$this->assertEquals( 'Article title', $this->instant_articles_post->get_the_title() );
-		$this->assertEquals( 'Article title',  $this->instant_articles_post->get_the_title_rss() );
-		$this->assertEquals( 'http://' . WP_TESTS_DOMAIN . '/?p=' . $this->post_id,  $this->instant_articles_post->get_canonical_url() );
-		$this->assertTrue( is_string( $this->instant_articles_post->get_the_excerpt() ), 'Expected string assertion failed.' );
-		$this->assertTrue( is_string( $this->instant_articles_post->get_the_excerpt_rss() ), 'Expected string assertion failed.' );
+	public function test_can_get_post_fields(): void {
+		self::assertSame( 'Article title', $this->instant_articles_post->get_the_title() );
+		self::assertSame( 'Article title', $this->instant_articles_post->get_the_title_rss() );
+		self::assertSame( 'http://' . WP_TESTS_DOMAIN . '/?p=' . $this->post_id,  $this->instant_articles_post->get_canonical_url() );
+		self::assertIsString( $this->instant_articles_post->get_the_excerpt(), 'Expected string assertion failed.' );
+		self::assertIsString( $this->instant_articles_post->get_the_excerpt_rss(), 'Expected string assertion failed.' );
 	}
 
-	public function testGetFeaturedImage_NoImage_HasArray() {
-		$this->assertTrue( is_array( $this->instant_articles_post->get_the_featured_image() ) );
+	public function test_featured_image_is_array(): void {
+		self::assertIsArray( $this->instant_articles_post->get_the_featured_image() );
 	}
 
-	public function testGetTheKicker_NoCategory() {
-		$this->assertEmpty( $this->instant_articles_post->get_the_kicker() );
+	public function test_kicker_is_empty_for_no_category(): void {
+		self::assertEmpty( $this->instant_articles_post->get_the_kicker() );
 	}
 }


### PR DESCRIPTION
- Use self::factory() method instead of deprecated $this->factory property. See https://core.trac.wordpress.org/changeset/54087
- Use more accurate assertions (Equals -> Same, Equals -> Count, Equals -> IsString/IsArray, etc.)
- Add a property to stop it being dynamic.
- Declare strict_types=1 in test files.
- Rename test methods to camel case.