### PR TITLE
Fix wizard option dynamic properties for PHP 8.2

### DIFF
--- a/wizard/class-instant-articles-option-fb-app.php
+++ b/wizard/class-instant-articles-option-fb-app.php
@@ -49,7 +49,7 @@ class Instant_Articles_Option_FB_App extends Instant_Articles_Option {
 	 * @since 0.4
 	 */
 	public function __construct() {
-		$this->options_manager = new parent(
+		parent::__construct(
 			self::OPTION_KEY,
 			self::$sections,
 			self::$fields

--- a/wizard/class-instant-articles-option-fb-page.php
+++ b/wizard/class-instant-articles-option-fb-page.php
@@ -38,7 +38,7 @@ class Instant_Articles_Option_FB_Page extends Instant_Articles_Option {
 	 * @since 0.4
 	 */
 	public function __construct() {
-		$this->options_manager = new parent(
+		parent::__construct(
 			self::OPTION_KEY,
 			self::$sections,
 			self::$fields


### PR DESCRIPTION
Makes the constructor of these two option classes match the others.

Fixes #683.